### PR TITLE
Fix ja-JP locale

### DIFF
--- a/html/locale.js
+++ b/html/locale.js
@@ -24,13 +24,13 @@ const LOCALE_SRC = {
   "ja-JP": {
     lang: "言語",
     gyroscope: "水準器",
-    mute: "靜音",
+    mute: "静音",
     magic: "自動",
     weibo: "微博",
     image: "絵",
-    program: "網頁",
+    program: "開発",
     date: "デート",
-    home: "標準"
+    home: "ホーム",
   },
 };
 const AVAIL_LANGS = Object.keys(LOCALE_SRC).sort();
@@ -39,8 +39,8 @@ const locale = {
   get: () => {
     let lang = "zh-CN";
     let paramLang = new URLSearchParams(location.search).get("lang");
-    if(paramLang){
-      paramLang = paramLang.replace('_','-');
+    if (paramLang) {
+      paramLang = paramLang.replace("_", "-");
     }
     if (AVAIL_LANGS.includes(paramLang)) {
       lang = paramLang;


### PR DESCRIPTION
- `靜音` → `静音`
修正为日本语的汉字。

- `網頁` → `開発`
日本语不使用 "網頁"。"程序"的正确翻译是"プログラム"。但是很长，所以我把它改为"開発 (开发, development)"。

- `標準` → `ホーム`
"標準"不是用来指"首页"和"Home"的。